### PR TITLE
Fix 404 handling for user lookup

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -165,6 +165,8 @@ def read_user_by_id(
     Get a specific user by id.
     """
     user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
     if user == current_user:
         return user
     if "superuser" not in current_user.permissions:


### PR DESCRIPTION
## Summary
- return a 404 when requesting a non-existent user by ID

## Testing
- `pytest -k read_user_by_id -q app/tests/api/routes/test_users.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68455f124ed083328f3352e29dbe4d3f